### PR TITLE
.gitignore 파일에 kalena 바이너리 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /bin
 .DS_Store
 assets_vfsdata.go
+kalena
+kalena.exe


### PR DESCRIPTION
go build를 사용할 때 kalena 바이너리가 /bin 바깥에 생성되어
이 파일들이 실수로 추가될 여지가 있다.